### PR TITLE
feat: Override method_missing to determine data access for an API response

### DIFF
--- a/lib/lotr/sdk.rb
+++ b/lib/lotr/sdk.rb
@@ -3,6 +3,7 @@
 require "http"
 require_relative "sdk/client"
 require_relative "sdk/exception"
+require_relative "sdk/resource"
 require_relative "sdk/movie"
 require_relative "sdk/quote"
 require_relative "sdk/version"

--- a/lib/lotr/sdk/client.rb
+++ b/lib/lotr/sdk/client.rb
@@ -7,6 +7,8 @@ module Lotr
       ID_REGEX = /^[0-9a-f]{24}$/i.freeze
       MOVIES_WITH_QUOTES = %w[5cd95395de30eff6ebccde5c 5cd95395de30eff6ebccde5b 5cd95395de30eff6ebccde5d"].freeze # IDs for the original trilogy
 
+      attr_reader :client
+
       # Initialize client with an access token
       #   1. Sign up at https://the-one-api.dev/sign-up
       #   2. Provide the access token.
@@ -14,7 +16,7 @@ module Lotr
       #          or
       #        Set the token to the THE_ONE_ACCESS_TOKEN env variable
       def initialize(access_token: nil)
-        @api_url = "https://the-one-api.dev/v2"
+        @api_url ="https://the-one-api.dev/v2"
         if access_token.nil?
           access_token = ENV["THE_ONE_ACCESS_TOKEN"]
         end

--- a/lib/lotr/sdk/movie.rb
+++ b/lib/lotr/sdk/movie.rb
@@ -3,60 +3,6 @@
 module Lotr
   module Sdk
     # Movie represents the data of a movie.
-    class Movie
-      attr_reader :data
-
-      def initialize(data)
-        @data = data
-      end
-
-      # Represents the movie ID
-      # @return [String]
-      def id
-        @data["_id"]
-      end
-
-      # Represents the movie title
-      # @return [String]
-      def name
-        @data["name"]
-      end
-
-      # Represents the movie length
-      # @return [Integer]
-      def run_time_minutes(format: false)
-        @data["runtimeInMinutes"]
-      end
-
-      # Represents the movie budget in milions
-      # @return [Integer]
-      def budget_millions
-        @data["budgetInMillions"]
-      end
-
-      # Represents the movie revenue in milions
-      # @return [Integer]
-      def revenue_millions
-        @data["boxOfficeRevenueInMillions"]
-      end
-
-      # Represents the number of Academy Award nominations
-      # @return [Integer]
-      def academy_award_nominations
-        @data["academyAwardNominations"]
-      end
-
-      # Represents the number of Academy Awards won
-      # @return [Integer]
-      def academy_award_wins
-        @data["academyAwardWins"]
-      end
-
-      # Represents the score out of 100 on Rotten Tomatoes
-      # @return [Integer]
-      def rotten_tomatoes_score
-        @data["rottenTomatoesScore"]
-      end
-    end
+    class Movie < Resource; end
   end
 end

--- a/lib/lotr/sdk/quote.rb
+++ b/lib/lotr/sdk/quote.rb
@@ -3,37 +3,6 @@
 module Lotr
   module Sdk
     # Quote represents the data of a quote.
-    class Quote
-      attr_reader :data
-
-      def initialize(data)
-        @data = data
-      end
-
-      # Represents the quote ID
-      # @return [String]
-      def id
-        @data["_id"]
-      end
-
-      # Represents the quote text
-      # @return [String]
-      def dialog
-        @data["dialog"]
-      end
-
-      # Fetch the ID of the movie the quote comes from
-      # @return [String]
-      def movie
-        @data["movie"]
-      end
-
-      # Represents the character that spoke the quote
-      # Characters are not supported in this version of the SDK
-      # @return [String]
-      def character
-        @data["character"]
-      end
-    end
+    class Quote < Resource; end
   end
 end

--- a/lib/lotr/sdk/resource.rb
+++ b/lib/lotr/sdk/resource.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Lotr
+  module Sdk
+    # Resource is the base class to infer a model
+    class Resource
+      attr_reader :data
+
+      def initialize(data)
+        @data = data
+      end
+
+      # List available data access methods
+      # @return [Array<String>]
+      def data_access_methods
+        @data.keys.map { |k| snakecase(k) }
+      end
+
+      # Get ID from data
+      # @return [String]
+      def id
+        @data["_id"]
+      end
+
+      # Override method_missing to access data from the API response
+      def method_missing(method)
+        if data_access_methods.include?(method.to_s)
+          @data[camelcase(method.to_s)]
+        else
+          super
+        end
+      end
+
+      # Define respond_to_missing? whenever overriding method_missing
+      def respond_to_missing?(method, *)
+        data_access_methods.include?(method.to_s)
+      end
+
+      private
+
+        def camelcase(string)
+          components = string.split("_")
+          ([components[0]] + components[1..].map(&:capitalize)).join
+        end
+
+        def snakecase(string)
+          string.scan(/[A-z][a-z]*/).map(&:downcase).join("_")
+        end
+    end
+  end
+end

--- a/spec/lotr/sdk/movie_spec.rb
+++ b/spec/lotr/sdk/movie_spec.rb
@@ -33,21 +33,21 @@ module Lotr
           end
         end
 
-        describe "#run_time_minutes" do
-          it "returns run time in minutes" do
-            expect(Movie.new(data).run_time_minutes).to eq(558)
+        describe "#runtime_in_minutes" do
+          it "returns runtime in minutes" do
+            expect(Movie.new(data).runtime_in_minutes).to eq(558)
           end
         end
 
-        describe "#budget_millions" do
+        describe "#budget_in_millions" do
           it "returns the budget in millions" do
-            expect(Movie.new(data).budget_millions).to eq(281)
+            expect(Movie.new(data).budget_in_millions).to eq(281)
           end
         end
 
-        describe "#revenue_millions" do
+        describe "#box_office_revenue_in_millions" do
           it "returns the revenue in millions" do
-            expect(Movie.new(data).revenue_millions).to eq(2917)
+            expect(Movie.new(data).box_office_revenue_in_millions).to eq(2917)
           end
         end
 

--- a/spec/lotr/sdk/resource_spec.rb
+++ b/spec/lotr/sdk/resource_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Lotr
+  module Sdk
+    RSpec.describe Resource do
+      let(:data) do
+        {
+          "singleword" => 1,
+          "twoWords" => 2,
+          "capitalizeThreeWords" => 3
+        }
+      end
+
+      describe "#data_access_methods" do
+        it "returns list of methods based on data" do
+          expect(Resource.new(data).data_access_methods).to match_array(%w[singleword two_words capitalize_three_words])
+        end
+      end
+
+      describe "#method_missing" do
+        it "counts data_access_methods as methods" do
+          resource = Resource.new(data)
+          resource.data_access_methods.each do |method_name|
+            expect(resource.respond_to?(method_name)).to be_truthy
+          end
+        end
+
+        context "camelCase" do
+          it "raises NoMethodError" do
+            resource = Resource.new(data)
+            expect(resource.singleword).to eq(1)
+            expect { resource.twoWords }.to raise_error(NoMethodError)
+            expect { resource.capitalizeThreeWords }.to raise_error(NoMethodError)
+          end
+        end
+
+        context "snake_case" do
+          it "access the data" do
+            resource = Resource.new(data)
+            expect(resource.singleword).to eq(1)
+            expect(resource.two_words).to eq(2)
+            expect(resource.capitalize_three_words).to eq(3)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Overview

Proof of concept for an identified area of improvement. This PR creates a `Resource` base class to easily model data retrieved from The One API. Since that API uses camelcase keys in its JSON response, the `Resource` class converts those keys to `snake_case` (idiomatic Ruby) and makes those available as accessor methods on the stored JSON response.

In other words:
```
data = { "someImportantField" => "Important info" }
resource = Resource.new(data)
resource.data_access_methods                       # => ["some_important_field"]
resource.respond_to?(:some_important_field)        # => true
resource.some_important_field                      # => "Important info"
```

# Pros & Cons
Pros:
- Easy to model other data
- Less code to write

Cons:
- Hard to version. If the API changes, the SDK changes immediately.
- Can't implement protections like schema validation, because the definition of the API response is not locked.