### PR TITLE
DRY up methods and handle pagination

### DIFF
--- a/spec/lotr/client_spec.rb
+++ b/spec/lotr/client_spec.rb
@@ -64,6 +64,15 @@ module Lotr
           result = Client.new.quotes
           expect(result.any?).to be_truthy
           expect(result.map(&:class).uniq.first).to eq(Lotr::Sdk::Quote)
+          expect(result.length).to eq(100)
+        end
+
+        context "when fetch_all = true" do
+          it "returns all quotes" do
+            result = Client.new.quotes(q: { limit: 1000 }, fetch_all: true)
+            expect(result.map(&:class).uniq.first).to eq(Lotr::Sdk::Quote)
+            expect(result.length > 1000).to be_truthy
+          end
         end
       end
 


### PR DESCRIPTION
Each method now follows this format:

1. Update default params with user-specified params
2. Call the API with endpoint and query params
3. Convert the API response to the corresponding model
4. Run through pagination if specified